### PR TITLE
Move onnx-caffe2 into caffe2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | Framework / tool | Installation | Exporting to ONNX (frontend) | Importing ONNX models (backend) |
 | --- | --- | --- | --- |
-| [Caffe2](http://caffe2.ai) | [onnx/onnx-caffe2](https://github.com/onnx/onnx-caffe2) | [Exporting](tutorials/Caffe2OnnxExport.ipynb) | [Importing](tutorials/OnnxCaffe2Import.ipynb) |
+| [Caffe2](http://caffe2.ai) | [caffe2/onnx-caffe2](https://github.com/caffe2/caffe2/tree/master/caffe2/python/onnx) | [Exporting](tutorials/Caffe2OnnxExport.ipynb) | [Importing](tutorials/OnnxCaffe2Import.ipynb) |
 | [PyTorch](http://pytorch.org/) | [part of pytorch package](http://pytorch.org/docs/master/onnx.html) | [Exporting](tutorials/PytorchOnnxExport.ipynb), [Extending support](tutorials/PytorchAddExportSupport.md) | coming soon |
 | [Cognitive Toolkit (CNTK)](https://www.microsoft.com/en-us/cognitive-toolkit/) | [built-in](https://docs.microsoft.com/en-us/cognitive-toolkit/setup-cntk-on-your-machine) | [Exporting](tutorials/CntkOnnxExport.ipynb) | [Importing](tutorials/OnnxCntkImport.ipynb) |
 | [Apache MXNet](http://mxnet.incubator.apache.org/) | [onnx/onnx-mxnet](https://github.com/onnx/onnx-mxnet) | coming soon | [Importing](tutorials/OnnxMxnetImport.ipynb) [experimental] |

--- a/tutorials/Caffe2OnnxExport.ipynb
+++ b/tutorials/Caffe2OnnxExport.ipynb
@@ -27,11 +27,7 @@
    "source": [
     "### Installation\n",
     "\n",
-    "The only thing you need for exporting Caffe2 models to ONNX is the python package `onnx-caffe2`:\n",
-    "\n",
-    "```shell\n",
-    "$ pip install onnx-caffe2\n",
-    "```"
+    "`onnx-caffe2` is now integrated as part of `caffe2` under `caffe2/python/onnx`.",
    ]
   },
   {
@@ -57,7 +53,7 @@
    "outputs": [],
    "source": [
     "import onnx\n",
-    "import onnx_caffe2.frontend\n",
+    "import caffe2.python.onnx.frontend\n",
     "from caffe2.proto import caffe2_pb2\n",
     "\n",
     "# We need to provide type and shape of the model inputs, \n",
@@ -76,7 +72,7 @@
     "with open('init_net.pb', 'rb') as f:\n",
     "    init_net.ParseFromString(f.read())\n",
     "\n",
-    "onnx_model = onnx_caffe2.frontend.caffe2_net_to_onnx_model(\n",
+    "onnx_model = caffe2.python.onnx.frontend.caffe2_net_to_onnx_model(\n",
     "    predict_net,\n",
     "    init_net,\n",
     "    value_info,\n",

--- a/tutorials/CorrectnessVerificationAndPerformanceComparison.ipynb
+++ b/tutorials/CorrectnessVerificationAndPerformanceComparison.ipynb
@@ -13,7 +13,7 @@
     "We choose PyTorch to export the ONNX model, and use Caffe2 as the backend.\n",
     "After that, the outputs and performance of two models are compared.\n",
     "\n",
-    "To run this tutorial, please make sure that `caffe2`, `pytorch`, `onnx`, `onnx-caffe2` are already installed.\n",
+    "To run this tutorial, please make sure that `caffe2`, `pytorch` and `onnx` are already installed.\n",
     "\n",
     "First, let's create a PyTorch model and prepare the inputs of the model."
    ]
@@ -48,8 +48,8 @@
     "from caffe2.proto import caffe2_pb2\n",
     "from caffe2.python import core\n",
     "from torch.autograd import Variable\n",
-    "from onnx_caffe2.backend import Caffe2Backend\n",
-    "from onnx_caffe2.helper import c2_native_run_net, save_caffe2_net, load_caffe2_net, \\\n",
+    "from caffe2.python.onnx.backend import Caffe2Backend\n",
+    "from caffe2.python.onnx.helper import c2_native_run_net, save_caffe2_net, load_caffe2_net, \\\n",
     "    benchmark_caffe2_model, benchmark_pytorch_model\n",
     "\n",
     "\n",

--- a/tutorials/OnnxCaffe2Import.ipynb
+++ b/tutorials/OnnxCaffe2Import.ipynb
@@ -21,11 +21,7 @@
    "source": [
     "### Installation\n",
     "\n",
-    "The only thing you need for importing ONNX models to Caffe2 is the python package `onnx-caffe2`:\n",
-    "\n",
-    "```shell\n",
-    "$ pip install onnx-caffe2\n",
-    "```"
+    "`onnx-caffe2` is now integrated as part of `caffe2` under `caffe2/python/onnx`.",
    ]
   },
   {
@@ -42,7 +38,7 @@
    "outputs": [],
    "source": [
     "import onnx\n",
-    "import onnx_caffe2.backend\n",
+    "import caffe2.python.onnx.backend\n",
     "\n",
     "# Prepare the inputs, here we use numpy to generate some random inputs for demo purpose\n",
     "import numpy as np\n",
@@ -51,7 +47,7 @@
     "# Load the ONNX model\n",
     "model = onnx.load('assets/squeezenet.onnx')\n",
     "# Run the ONNX model with Caffe2\n",
-    "outputs = onnx_caffe2.backend.run_model(model, [img])"
+    "outputs = caffe2.python.onnx.backend.run_model(model, [img])"
    ]
   },
   {

--- a/tutorials/PytorchCaffe2MobileSqueezeNet.ipynb
+++ b/tutorials/PytorchCaffe2MobileSqueezeNet.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "In this tutorial we'll show how to export squeezenet which is implemented and trained in pytorch to run on mobile devices.\n",
-    "Before we start, you should have [pytorch](https://github.com/pytorch/pytorch), [caffe2](https://github.com/caffe2/caffe2), [onnx](https://github.com/onnx/onnx) and [onnx-caffe2](https://github.com/onnx/onnx-caffe2) installed in your environment and cloned [AICamera](https://github.com/bwasti/AICamera).\n",
+    "Before we start, you should have [pytorch](https://github.com/pytorch/pytorch), [caffe2](https://github.com/caffe2/caffe2), and [onnx](https://github.com/onnx/onnx) installed in your environment and cloned [AICamera](https://github.com/bwasti/AICamera).\n",
     "Please checkout their github page for installation instructions."
    ]
   },
@@ -216,7 +216,7 @@
    "outputs": [],
    "source": [
     "import onnx\n",
-    "import onnx_caffe2.backend\n",
+    "import caffe2.python.onnx.backend\n",
     "from onnx import helper\n",
     "\n",
     "# Load the ONNX GraphProto object. Graph is a standard Python protobuf object\n",
@@ -225,7 +225,7 @@
     "# prepare the caffe2 backend for executing the model this converts the ONNX graph into a\n",
     "# Caffe2 NetDef that can execute it. Other ONNX backends, like one for CNTK will be\n",
     "# availiable soon.\n",
-    "prepared_backend = onnx_caffe2.backend.prepare(model)\n",
+    "prepared_backend = caffe2.python.onnx.backend.prepare(model)\n",
     "\n",
     "# run the model in Caffe2\n",
     "\n",
@@ -256,7 +256,7 @@
    "outputs": [],
    "source": [
     "# Export to mobile\n",
-    "from onnx_caffe2.backend import Caffe2Backend as c2\n",
+    "from caffe2.python.onnx.backend import Caffe2Backend as c2\n",
     "\n",
     "init_net, predict_net = c2.onnx_graph_to_caffe2_net(model.graph)\n",
     "with open(\"squeeze_init_net.pb\", \"wb\") as f:\n",

--- a/tutorials/PytorchCaffe2SuperResolution.ipynb
+++ b/tutorials/PytorchCaffe2SuperResolution.ipynb
@@ -20,7 +20,7 @@
     "For this tutorial, you will need to install [onnx](https://github.com/onnx/onnx),\n",
     "and [Caffe2](https://caffe2.ai/).\n",
     "You can get binary builds of onnx with\n",
-    "``conda install -c ezyang onnx``.\n",
+    "``conda install -c conda-forge onnx``.\n",
     "\n",
     "``NOTE``: This tutorial needs PyTorch master branch which can be installed by following\n",
     "[the instructions here](https://github.com/pytorch/pytorch#from-source)"

--- a/tutorials/PytorchCaffe2SuperResolution.ipynb
+++ b/tutorials/PytorchCaffe2SuperResolution.ipynb
@@ -18,9 +18,9 @@
     "executing the model on mobile devices.\n",
     "\n",
     "For this tutorial, you will need to install [onnx](https://github.com/onnx/onnx),\n",
-    "[onnx-caffe2](https://github.com/onnx/onnx-caffe2) and [Caffe2](https://caffe2.ai/).\n",
-    "You can get binary builds of onnx and onnx-caffe2 with\n",
-    "``conda install -c ezyang onnx onnx-caffe2``.\n",
+    "and [Caffe2](https://caffe2.ai/).\n",
+    "You can get binary builds of onnx with\n",
+    "``conda install -c ezyang onnx``.\n",
     "\n",
     "``NOTE``: This tutorial needs PyTorch master branch which can be installed by following\n",
     "[the instructions here](https://github.com/pytorch/pytorch#from-source)"
@@ -44,7 +44,7 @@
     "import torch.onnx\n",
     "\n",
     "import onnx\n",
-    "import onnx_caffe2.backend"
+    "import caffe2.python.onnx.backend"
    ]
   },
   {
@@ -203,7 +203,7 @@
     "# prepare the caffe2 backend for executing the model this converts the ONNX model into a \n",
     "# Caffe2 NetDef that can execute it. Other ONNX backends, like one for CNTK will be \n",
     "# availiable soon.\n",
-    "prepared_backend = onnx_caffe2.backend.prepare(model)\n",
+    "prepared_backend = caffe2.python.onnx.backend.prepare(model)\n",
     "\n",
     "# run the model in Caffe2\n",
     "\n",


### PR DESCRIPTION
Since we have moved `onnx-caffe2` into `caffe2`. Update the documentation here.