### PR TITLE
Fix notebook syntax

### DIFF
--- a/tutorials/Caffe2OnnxExport.ipynb
+++ b/tutorials/Caffe2OnnxExport.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "### Installation\n",
     "\n",
-    "`onnx-caffe2` is now integrated as part of `caffe2` under `caffe2/python/onnx`.",
+    "`onnx-caffe2` is now integrated as part of `caffe2` under `caffe2/python/onnx`."
    ]
   },
   {

--- a/tutorials/OnnxCaffe2Import.ipynb
+++ b/tutorials/OnnxCaffe2Import.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "### Installation\n",
     "\n",
-    "`onnx-caffe2` is now integrated as part of `caffe2` under `caffe2/python/onnx`.",
+    "`onnx-caffe2` is now integrated as part of `caffe2` under `caffe2/python/onnx`."
    ]
   },
   {


### PR DESCRIPTION
PyNotebook is of json format, not python. Fix syntax so that It can be run and rendered again. 

It's showing up:
https://github.com/yinghai/tutorials/blob/fix/tutorials/Caffe2OnnxExport.ipynb
https://github.com/yinghai/tutorials/blob/fix/tutorials/OnnxCaffe2Import.ipynb

Test Plan:
```
pytest --nbval Caffe2OnnxExport.ipynb
```