### PR TITLE
Fix runtime error for onnx_graph_to_caffe2_net

### DIFF
--- a/tutorials/PytorchCaffe2MobileSqueezeNet.ipynb
+++ b/tutorials/PytorchCaffe2MobileSqueezeNet.ipynb
@@ -258,7 +258,7 @@
     "# Export to mobile\n",
     "from caffe2.python.onnx.backend import Caffe2Backend as c2\n",
     "\n",
-    "init_net, predict_net = c2.onnx_graph_to_caffe2_net(model.graph)\n",
+    "init_net, predict_net = c2.onnx_graph_to_caffe2_net(model)\n",
     "with open(\"squeeze_init_net.pb\", \"wb\") as f:\n",
     "    f.write(init_net.SerializeToString())\n",
     "with open(\"squeeze_predict_net.pb\", \"wb\") as f:\n",


### PR DESCRIPTION
Got 'The model does not have an ir_version set properly' exception
when passing model.graph to onnx_graph_to_caffe2_net. The checker
takes model parameter therefore pass model instead of graph.