### PR TITLE
Fix runtime link error for OnnxTensorflowExport.ipnb

### DIFF
--- a/tutorials/OnnxTensorflowExport.ipynb
+++ b/tutorials/OnnxTensorflowExport.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "### Model Conversion\n",
     "\n",
-    "Thirdly, we convert the model to ONNX format using onnx-tensorflow. Using `tensorflow_graph_to_onnx_model` from onnx-tensorflow API (documentation available at https://github.com/onnx/onnx-tensorflow/blob/master/onnx_tf/doc/API.md)."
+    "Thirdly, we convert the model to ONNX format using onnx-tensorflow. Using `tensorflow_graph_to_onnx_model` from onnx-tensorflow API (documentation available at https://github.com/onnx/onnx-tensorflow/blob/master/doc/API.md)."
    ]
   },
   {


### PR DESCRIPTION
this link is not a available, fix it.
https://github.com/onnx/onnx-tensorflow/blob/master/onnx_tf/doc/API.md