### PR TITLE
Be more explicit to avoid decode error in python3

### DIFF
--- a/tutorials/PytorchCaffe2MobileSqueezeNet.ipynb
+++ b/tutorials/PytorchCaffe2MobileSqueezeNet.ipynb
@@ -287,9 +287,9 @@
    ],
    "source": [
     "# Verify it runs with predictor\n",
-    "with open(\"squeeze_init_net.pb\") as f:\n",
+    "with open(\"squeeze_init_net.pb\", \"rb\") as f:\n",
     "    init_net = f.read()\n",
-    "with open(\"squeeze_predict_net.pb\") as f:\n",
+    "with open(\"squeeze_predict_net.pb\", \"rb\") as f:\n",
     "    predict_net = f.read()\n",
     "from caffe2.python import workspace\n",
     "p = workspace.Predictor(init_net, predict_net)\n",


### PR DESCRIPTION
Great work with the tutorials guys! they've been super helpful.
This fixes a tiny bug: In python3 I ran into `UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 24: ordinal not in range(128)` at the very last step of reading in the pb files. Added in the binary flag when reading to mirror how it was written and that did the trick so figured I'd PR to save some time for the next person