### PR TITLE
remove the example of runtime server

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Once you have an ONNX model, it can be scored with a variety of tools.
   * [Serving ONNX models with AI-Serving](https://github.com/autodeployai/ai-serving/blob/master/examples/AIServingMnistOnnxModel.ipynb)
   * [Serving ONNX models with Cortex](https://towardsdatascience.com/how-to-deploy-onnx-models-in-production-60bd6abfd3ae)
   * [Serving ONNX models with MXNet Model Server](tutorials/ONNXMXNetServer.ipynb)
-  * [Serving ONNX models with ONNX Runtime Server](tutorials/OnnxRuntimeServerSSDModel.ipynb)
   * [ONNX model hosting with AWS SageMaker and MXNet](https://github.com/awslabs/amazon-sagemaker-examples/blob/master/sagemaker-python-sdk/mxnet_onnx_eia/mxnet_onnx_eia.ipynb)
   * [Serving ONNX models with ONNX Runtime on Azure ML](https://github.com/Azure/MachineLearningNotebooks/tree/master/how-to-use-azureml/deployment/onnx)
     * [FER Facial Expression Recognition](https://github.com/Azure/MachineLearningNotebooks/blob/master/how-to-use-azureml/deployment/onnx/onnx-inference-facial-expression-recognition-deploy.ipynb)


### PR DESCRIPTION
The onnx runtime server is no longer supported, there is no point to have the example here.

Please refer to [https://github.com/microsoft/onnxruntime/pull/7818](https://github.com/microsoft/onnxruntime/pull/7818)