### PR TITLE
Fix broken URL: moving from model-evaluation to model-inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Once you have an ONNX model, it can be scored with a variety of tools.
 | [Tensorflow](https://www.tensorflow.org/) | [onnx-tensorflow](https://github.com/onnx/onnx-tensorflow) | [Example](tutorials/OnnxTensorflowImport.ipynb)|
 | [TensorRT](https://developer.nvidia.com/tensorrt) | [onnx-tensorrt](https://github.com/onnx/onnx-tensorrt) | [Example](https://github.com/onnx/onnx-tensorrt/blob/master/README.md) |
 | [Windows ML](https://docs.microsoft.com/en-us/windows/ai/windows-ml) | Pre-installed on [Windows 10](https://docs.microsoft.com/en-us/windows/ai/release-notes) | [API](https://docs.microsoft.com/en-us/windows/ai/api-reference)<br>Tutorials - [C++ Desktop App](https://docs.microsoft.com/en-us/windows/ai/get-started-desktop), [C# UWP App](https://docs.microsoft.com/en-us/windows/ai/get-started-uwp)<br> [Examples](https://docs.microsoft.com/en-us/windows/ai/tools-and-samples) |
-| [Vespa.ai](https://vespa.ai) | [Vespa Getting Started Guide](https://docs.vespa.ai/en/getting-started.html) | [Real Time ONNX Inference](https://github.com/vespa-engine/sample-apps/tree/master/model-evaluation)<br>Distributed Real Time ONNX Inference for [Search and Passage Ranking](https://github.com/vespa-engine/sample-apps/blob/master/msmarco-ranking/passage-ranking.md)|
+| [Vespa.ai](https://vespa.ai) | [Vespa Getting Started Guide](https://docs.vespa.ai/en/getting-started.html) | [Real Time ONNX Inference](https://github.com/vespa-engine/sample-apps/tree/master/model-inference)<br>Distributed Real Time ONNX Inference for [Search and Passage Ranking](https://github.com/vespa-engine/sample-apps/blob/master/msmarco-ranking/passage-ranking.md)|
 
 
 ## End-to-End Tutorials


### PR DESCRIPTION
**Description**
Moving from model-evaluation to model-inference.

**Motivation and Context**
Weekly CI failed due to recent update from: https://github.com/vespa-engine/sample-apps/commit/ea665221c07917b10b73d1b4a688c71105996d8e. Moving from model-evaluation to model-inference.

The error log: https://github.com/onnx/tutorials/runs/7830256986?check_suite_focus=true#step:6:141
```
-----------validate ./README.md
https://github.com/vespa-engine/sample-apps/tree/master/model-evaluation: is Not reachable, Exception: HTTP Error 404: Not Found
```